### PR TITLE
Update UID and overwrite callback_phase method for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.2]
+
+- Update uid to use organization id id
+- Added token response into omniauth hash
+
 ## [1.0.1]
 
 - Bugfix: added client secret to token params request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update uid to use organization id id
 - Added token response into omniauth hash
+- Overwrite callback_phase method to not fail upon missing refresh token
 
 ## [1.0.1]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-miro (1.0.1)
+    omniauth-miro (1.0.2)
       omniauth (>= 1, < 3)
       omniauth-oauth2 (~> 1.1)
 

--- a/lib/omni_auth/miro/version.rb
+++ b/lib/omni_auth/miro/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Miro
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end

--- a/lib/omni_auth/strategies/miro.rb
+++ b/lib/omni_auth/strategies/miro.rb
@@ -46,6 +46,25 @@ module OmniAuth
           params[:redirect_uri] = callback_url
         end
       end
+
+      def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+        error = request.params["error_reason"] || request.params["error"]
+        if !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
+          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+        elsif error
+          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
+        else
+          self.access_token = build_access_token
+          env['omniauth.auth'] = auth_hash
+          call_app!
+        end
+      rescue ::OAuth2::Error, CallbackError => e
+        fail!(:invalid_credentials, e)
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+        fail!(:timeout, e)
+      rescue ::SocketError => e
+        fail!(:failed_to_connect, e)
+      end
     end
   end
 end

--- a/lib/omni_auth/strategies/miro.rb
+++ b/lib/omni_auth/strategies/miro.rb
@@ -47,12 +47,13 @@ module OmniAuth
         end
       end
 
-      def callback_phase # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-        error = request.params["error_reason"] || request.params["error"]
-        if !options.provider_ignores_state && (request.params["state"].to_s.empty? || request.params["state"] != session.delete("omniauth.state"))
-          fail!(:csrf_detected, CallbackError.new(:csrf_detected, "CSRF detected"))
+      def callback_phase
+        error = request.params['error_reason'] || request.params['error']
+        if !options.provider_ignores_state && (request.params['state'].to_s.empty? || request.params['state'] != session.delete('omniauth.state'))
+          fail!(:csrf_detected, CallbackError.new(:csrf_detected, 'CSRF detected'))
         elsif error
-          fail!(error, CallbackError.new(request.params["error"], request.params["error_description"] || request.params["error_reason"], request.params["error_uri"]))
+          fail!(error,
+                CallbackError.new(request.params['error'], request.params['error_description'] || request.params['error_reason'], request.params['error_uri']))
         else
           self.access_token = build_access_token
           env['omniauth.auth'] = auth_hash

--- a/lib/omni_auth/strategies/miro.rb
+++ b/lib/omni_auth/strategies/miro.rb
@@ -13,7 +13,7 @@ module OmniAuth
         token_url: 'https://api.miro.com/v1/oauth/token'
       }
 
-      uid { raw_info['team']['id'] }
+      uid { raw_info['organization']['id'] }
 
       info do
         {
@@ -26,7 +26,8 @@ module OmniAuth
 
       extra do
         {
-          raw_info: raw_info
+          raw_info: raw_info,
+          token_info: access_token
         }
       end
 


### PR DESCRIPTION
- Updated UID to be organization ID instead
- Overwrote the callback_phase method as we are getting a `null` access token due to a bug on Miro's end. We are allowing it to be null 