### PR TITLE
Chore/parth rewind/dependencies upgrade to latest minor versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.4]
+
+- Address CVE-2025-27221 by updating uri to 1.0.3
+- Update other dependencies to their respective latest minor versions
+
 ## [1.0.3]
 
 - Remove overwritten callback_phase method that skipped refresh_token existence check

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-miro (1.0.3)
+    omniauth-miro (1.0.4)
       omniauth (>= 1, < 3)
       omniauth-oauth2 (~> 1.1)
 
@@ -11,22 +11,27 @@ GEM
     ansi (1.5.0)
     ast (2.4.3)
     base64 (0.2.0)
+    bigdecimal (3.1.9)
     coderay (1.1.3)
-    diff-lcs (1.5.0)
-    docile (1.4.0)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
+    diff-lcs (1.6.1)
+    docile (1.4.1)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     hashie (5.0.0)
     json (2.10.2)
-    jwt (2.8.1)
+    jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
-    method_source (1.0.0)
-    multi_xml (0.6.0)
-    net-http (0.4.1)
+    logger (1.7.0)
+    method_source (1.1.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
+    net-http (0.6.0)
       uri
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -35,7 +40,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    omniauth (2.1.2)
+    omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
@@ -47,16 +52,17 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
-    pry (0.14.2)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     racc (1.8.1)
-    rack (3.0.9.1)
-    rack-protection (4.0.0)
+    rack (3.1.12)
+    rack-protection (4.1.1)
       base64 (>= 0.1.0)
+      logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.2.1)
     regexp_parser (2.10.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -85,9 +91,10 @@ GEM
     rubocop-ast (1.43.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
-    rubocop-performance (1.19.1)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
+    rubocop-performance (1.24.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-rspec (3.5.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -96,20 +103,22 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-console (0.9.1)
+    simplecov-console (0.9.3)
       ansi
       simplecov
       terminal-table
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.6.0)
-    uri (0.13.0)
-    version_gem (1.1.3)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    uri (1.0.3)
+    version_gem (1.1.6)
 
 PLATFORMS
   ruby

--- a/lib/omni_auth/miro/version.rb
+++ b/lib/omni_auth/miro/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Miro
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
## Description
- Address CVE-2025-27221 by updating uri to 1.0.3
- Update other dependencies to their respective latest minor versions