### PR TITLE
fix(): Include hidden files in upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
           name: coverage-results
           path: coverage
           retention-days: 5
+          include-hidden-files: true
 
   coverage:
     needs: rspec


### PR DESCRIPTION
## Description of Change
v4 of the upload-artifact action ignores hidden files during upload unless specified. Our actions we found are failing during code coverage steps because of a missing file which happens to be a dot file.